### PR TITLE
make clearing more robust

### DIFF
--- a/cordova/www/js/index.js
+++ b/cordova/www/js/index.js
@@ -61,6 +61,6 @@ var app = {
    },
    clearMessages: function() {
      var waiting = document.getElementById("waiting");
-     waiting.parentElement.removeChild(waiting);
+     waiting.style.display = 'none';
    }
 };


### PR DESCRIPTION
removing the waiting element only works if the page would be reloaded, but on cordova apps that is not the case